### PR TITLE
Use native JavaScript/ECMAScript module syntax

### DIFF
--- a/src/Data/Base64.js
+++ b/src/Data/Base64.js
@@ -7,7 +7,7 @@ function validateBase64(s) {
   }
 }
 
-exports.encodeBase64Impl = function (buffer) {
+export function encodeBase64Impl(buffer) {
   if (typeof btoa === 'undefined') {
     // Node
     return Buffer.from(buffer).toString('base64');
@@ -22,7 +22,7 @@ exports.encodeBase64Impl = function (buffer) {
   }
 };
 
-exports.decodeBase64Impl = function (just, nothing, str) {
+export function decodeBase64Impl(just, nothing, str) {
   try {
     validateBase64(str);
     if (typeof atob === 'undefined') {
@@ -43,7 +43,7 @@ exports.decodeBase64Impl = function (just, nothing, str) {
   }
 };
 
-exports.fromStringImpl = function (just, nothing, str) {
+export function fromStringImpl(just, nothing, str) {
   try {
     validateBase64(str);
     return just(str);


### PR DESCRIPTION
CommonJS foreign modules are no longer supported by new PureScript versions.